### PR TITLE
Change example output and better error handling

### DIFF
--- a/src/main/java/seedu/address/logic/commands/StatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatusCommand.java
@@ -29,7 +29,7 @@ public class StatusCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_STATUS + "[STATUS]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_STATUS + "Likes to swim.";
+            + PREFIX_STATUS + "blacklist";
 
     private final Index index;
     private final Status status;

--- a/src/main/java/seedu/address/logic/parser/StatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StatusCommandParser.java
@@ -10,6 +10,8 @@ import seedu.address.logic.commands.StatusCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Status;
 
+import java.util.NoSuchElementException;
+
 /**
  * Parses input arguments and creates a new {@code StatusCommand} object
  */
@@ -29,8 +31,13 @@ public class StatusCommandParser implements Parser<StatusCommand> {
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE), ive);
         }
-        Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
 
-        return new StatusCommand(index, status);
+        try {
+            Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
+            return new StatusCommand(index, status);
+        } catch (NoSuchElementException nsee) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, StatusCommand.MESSAGE_USAGE), nsee);
+        }
+
     }
 }

--- a/src/main/java/seedu/address/logic/parser/StatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StatusCommandParser.java
@@ -4,13 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 
+import java.util.NoSuchElementException;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.StatusCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Status;
-
-import java.util.NoSuchElementException;
 
 /**
  * Parses input arguments and creates a new {@code StatusCommand} object


### PR DESCRIPTION
Example output when receiving an invalid status command was wrong. Now, changed to the correct example.

Previously, typing "status 1" did not correctly give an invalid command. Now, it will output an "Invalid command" and show an example usage.