### PR TITLE
Add sort command to ModuleMateFinder

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -364,7 +364,12 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 ### Glossary
 
 * **Mainstream OS**: Windows, Linux, Unix, OS-X
+* **Contact/Person**: A classmate whose information is kept in the address book. 
+* **Module**: A course that is held at NUS with specific module codes e.g. CS3230
 * **Private contact detail**: A contact detail that is not meant to be shared with others
+* **Favourite**: To mark a person favourably
+* **Blacklist**: To mark a person unfavourably
+* **Fast Typist**: A person who can type at speeds greater or equal to 70 words per minute.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -236,6 +236,7 @@ Sort all people within address book.
 Format: `sort [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STATUS] [t/TAG] [o/ORDER]​`
 
 * Sorts list with specified field(s). For any two persons, latter fields will only be considered if preceding fields are equal.​
+* Order of parameters is important except for that of `o/ORDER`.
 * At least one of the optional fields must be provided (excluding order).
 * Parameters are ignored except for order `o/asc`.
 * Orders are optional and default order is "asc". Parameters of order must be either "asc" or "desc" and is case-insensitive. 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -229,6 +229,21 @@ Format: `filter t/TAG`
 Examples:
 * `filter t/CS3230`  will find all persons with the module CS3230
 
+### Sorting contacts in list: `sort`
+
+Sort all people within address book.
+
+Format: `sort [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STATUS] [t/TAG] [o/ORDER]​`
+
+* Sorts list with specified field(s). For any two persons, latter fields will only be considered if preceding fields are equal.​
+* At least one of the optional fields must be provided (excluding order).
+* Parameters are ignored except for order `o/asc`.
+* Orders are optional and default order is "asc". Parameters of order must be either "asc" or "desc" and is case-insensitive. 
+
+Examples:
+* `sort n/ p/`  will sort the list by name first. If two persons have the same name, then sort by phone number.
+* `sort n/ o/desc` will sort the list by name in descending order.
+
 ### Undo a command : `undo`
 
 Undoes the most recent command. 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_MORE_TAGS_THAN_EXPECTED = "There should only be 1 tag!";
+    public static final String MESSAGE_NO_PARAMETERS_SUPPLIED = "There are no parameters supplied!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,0 +1,121 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ORDER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Comparator;
+import java.util.List;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+public class SortCommand extends Command {
+    public static final String COMMAND_WORD = "sort";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Sorts entries in the AddressBook by the specified field(s).\n"
+            + "Order parameters are mandatory but specifying order is optional.\n"
+            + "All other parameters are optional.\n"
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_STATUS + "STATUS] "
+            + "[" + PREFIX_TAG + "TAG] "
+            + "[" + PREFIX_ORDER + "ORDER]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + " " + PREFIX_NAME
+            + " " + PREFIX_ORDER + "desc" + "\n";
+
+    public static final String MESSAGE_SUCCESS = "Sorted Modules successfully";
+
+    private final PersonComparator personComparator;
+    private final List<Prefix> fields;
+    /**
+     * @param fields modules to be deleted
+     */
+    public SortCommand(List<Prefix> fields, String order) {
+        this.fields = fields;
+        this.personComparator = new PersonComparator(fields, order);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.sortPerson(personComparator);
+        return new CommandResult(String.format(MESSAGE_SUCCESS));
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        return (other instanceof SortCommand)
+                && this.fields.equals(((SortCommand) other).fields)
+                && this.personComparator.equals(((SortCommand) other).personComparator); // instanceof handles null
+    }
+
+    public static class PersonComparator implements Comparator<Person> {
+        private final List<Prefix> fields;
+        private final String order;
+        /**
+         * Create a comparator using the specified fields,
+         * using the ordering implied by its iterator.
+         * @param fields a list of field names
+         */
+        public PersonComparator(List<Prefix> fields, String order) {
+            this.fields = fields;
+            this.order = order;
+        }
+
+        @Override
+        public int compare(Person o1, Person o2) {
+            for (Prefix field : fields) {
+                int result = 0;
+                if (PREFIX_NAME.equals(field)) {
+                    result = o1.getName().compareTo(o2.getName());
+
+                } else if (PREFIX_PHONE.equals(field)) {
+                    result = o1.getPhone().compareTo(o2.getPhone());
+
+                } else if (PREFIX_EMAIL.equals(field)) {
+                    result = o1.getEmail().compareTo(o2.getEmail());
+
+                } else if (PREFIX_ADDRESS.equals(field)) {
+                    result = o1.getAddress().compareTo(o2.getAddress());
+
+                } else if (PREFIX_TAG.equals(field)) {
+                    result = Integer.compare(o1.getTags().size(), o2.getTags().size());
+
+                } else if (PREFIX_STATUS.equals(field)) {
+                    result = o1.getStatus().compareTo(o2.getStatus());
+
+                }
+
+                if (order.equals("desc")) {
+                    result *= -1;
+                }
+
+                if (result != 0) {
+                    return result;
+                }
+            }
+            return 0;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            return (other instanceof PersonComparator)
+                    && this.fields.equals(((PersonComparator) other).fields)
+                    && this.order.equals(((PersonComparator) other).order); // instanceof handles null
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -34,7 +34,7 @@ public class SortCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + " " + PREFIX_NAME
             + " " + PREFIX_ORDER + "desc" + "\n";
 
-    public static final String MESSAGE_SUCCESS = "Sorted Modules successfully";
+    public static final String MESSAGE_SUCCESS = "Sorted Modules successfully: %s";
 
     private final PersonComparator personComparator;
     private final List<Prefix> fields;
@@ -50,7 +50,7 @@ public class SortCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.sortPerson(personComparator);
-        return new CommandResult(MESSAGE_SUCCESS + ": " + fields.toString());
+        return new CommandResult(String.format(MESSAGE_SUCCESS, fields.toString()));
     }
 
 

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -50,7 +50,7 @@ public class SortCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.sortPerson(personComparator);
-        return new CommandResult(String.format(MESSAGE_SUCCESS));
+        return new CommandResult(MESSAGE_SUCCESS + ": " + fields.toString());
     }
 
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.StatusCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -80,8 +81,13 @@ public class AddressBookParser {
 
         case StatusCommand.COMMAND_WORD:
             return new StatusCommandParser().parse(arguments);
+
         case FilterCommand.COMMAND_WORD:
             return new FilterCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
+
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -38,7 +38,7 @@ public class ArgumentTokenizer {
     public static List<Prefix> sortPrefixOrder(String argsString, Prefix... prefixes) {
         return findAllPrefixPositions(argsString, prefixes)
                 .stream()
-                .sorted((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition())
+                .sorted((prefix1, prefix2) -> Integer.compare(prefix1.getStartPosition(), prefix2.getStartPosition()))
                 .map(PrefixPosition::getPrefix)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -29,6 +29,21 @@ public class ArgumentTokenizer {
     }
 
     /**
+     * Create list of prefix based on their position in input.
+     *
+     * @param argsString Arguments string to find prefixes in
+     * @param prefixes   Prefixes to find in the arguments string
+     * @return List of prefix in the arguments string
+     */
+    public static List<Prefix> sortPrefixOrder(String argsString, Prefix... prefixes) {
+        return findAllPrefixPositions(argsString, prefixes)
+                .stream()
+                .sorted((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition())
+                .map(PrefixPosition::getPrefix)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Finds all zero-based prefix positions in the given arguments string.
      *
      * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,5 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_STATUS = new Prefix("s/");
+    public static final Prefix PREFIX_ORDER = new Prefix("o/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NO_PARAMETERS_SUPPLIED;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ORDER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.List;
+
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditCommand object
+ */
+public class SortCommandParser implements Parser<SortCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditCommand
+     * and returns an SortCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SortCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
+                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_STATUS, PREFIX_TAG, PREFIX_ORDER);
+
+        List<Prefix> prefixes = ArgumentTokenizer.sortPrefixOrder(args, PREFIX_NAME, PREFIX_PHONE,
+                PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_STATUS, PREFIX_TAG);
+
+        if (prefixes.size() == 0) {
+            throw new ParseException(MESSAGE_NO_PARAMETERS_SUPPLIED);
+        }
+
+        if (!argMultimap.getPreamble().equals("")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        }
+
+        if (argMultimap.getValue(PREFIX_ORDER).isPresent()) {
+            String order = argMultimap.getValue(PREFIX_ORDER).get().toLowerCase();
+            if (!order.equals("asc") && !order.equals("desc")) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+            }
+            return new SortCommand(prefixes, order);
+        }
+
+        return new SortCommand(prefixes, "asc");
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.address.logic.commands.SortCommand.PersonComparator;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -85,6 +86,12 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.setPerson(target, editedPerson);
     }
 
+    /**
+     * Sort persons in the address book with given PersonComparator {@code comparator}.
+     */
+    public void sortPerson(PersonComparator comparator) {
+        persons.sort(comparator);
+    }
     /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.SortCommand.PersonComparator;
 import seedu.address.model.person.Person;
 
 /**
@@ -75,6 +76,11 @@ public interface Model {
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedPerson);
+
+    /**
+     * Sort the person list with PersonComparator {@code comparator}.
+     */
+    void sortPerson(PersonComparator comparator);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.SortCommand.PersonComparator;
 import seedu.address.model.person.Person;
 
 /**
@@ -109,6 +110,11 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    @Override
+    public void sortPerson(PersonComparator comparator) {
+        addressBook.sortPerson(comparator);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's address in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
-public class Address {
+public class Address implements Comparable<Address> {
 
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
 
@@ -54,4 +54,8 @@ public class Address {
         return value.hashCode();
     }
 
+    @Override
+    public int compareTo(Address address) {
+        return this.value.compareTo(address.value);
+    }
 }

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
-public class Email {
+public class Email implements Comparable<Email> {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
@@ -68,4 +68,8 @@ public class Email {
         return value.hashCode();
     }
 
+    @Override
+    public int compareTo(Email email) {
+        return value.compareTo(email.value);
+    }
 }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
-public class Name {
+public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -56,4 +56,8 @@ public class Name {
         return fullName.hashCode();
     }
 
+    @Override
+    public int compareTo(Name name) {
+        return fullName.compareTo(name.fullName);
+    }
 }

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
  */
-public class Phone {
+public class Phone implements Comparable<Phone> {
 
 
     public static final String MESSAGE_CONSTRAINTS =
@@ -50,4 +50,8 @@ public class Phone {
         return value.hashCode();
     }
 
+    @Override
+    public int compareTo(Phone phone) {
+        return this.value.compareTo(phone.value);
+    }
 }

--- a/src/main/java/seedu/address/model/person/Status.java
+++ b/src/main/java/seedu/address/model/person/Status.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's status in the address book.
  * Guarantees: immutable; is always valid
  */
-public class Status {
+public class Status implements Comparable<Status> {
 
     public static final String MESSAGE_CONSTRAINTS = "Status should be either 'blacklist' or 'favourite'";
     public final String value;
@@ -45,5 +45,10 @@ public class Status {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(Status status) {
+        return value.compareTo(status.value);
     }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.logic.commands.SortCommand.PersonComparator;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
@@ -66,6 +67,13 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.set(index, editedPerson);
+    }
+
+    /**
+     * Sort the list using the given comparator.
+     */
+    public void sort(PersonComparator comparator) {
+        internalList.sort(comparator);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -134,6 +134,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void sortPerson(SortCommand.PersonComparator comparator) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setPerson(Person target, Person editedPerson) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -80,8 +80,6 @@ public class CommandTestUtil {
                                             Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
-            System.out.println(result.feedbackToUser);
-            System.out.println(expectedCommandResult.feedbackToUser);
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {

--- a/src/test/java/seedu/address/logic/commands/PersonComparatorTest.java
+++ b/src/test/java/seedu/address/logic/commands/PersonComparatorTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.SortCommand.PersonComparator;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class PersonComparatorTest {
+    @Test
+    public void equals() {
+        PersonComparator firstPersonComparator = new PersonComparator(Arrays.asList(PREFIX_NAME, PREFIX_EMAIL,
+                PREFIX_ADDRESS, PREFIX_STATUS), "asc");
+        PersonComparator secondPersonComparator = new PersonComparator(Arrays.asList(PREFIX_NAME,
+                PREFIX_STATUS), "desc");
+
+        // same object -> returns true
+        assertTrue(firstPersonComparator.equals(firstPersonComparator));
+
+        // same values -> returns true
+        PersonComparator firstPersonComparatorCopy = new PersonComparator(Arrays.asList(PREFIX_NAME, PREFIX_EMAIL,
+                PREFIX_ADDRESS, PREFIX_STATUS), "asc");
+        assertTrue(firstPersonComparator.equals(firstPersonComparatorCopy));
+
+        // different types -> returns false
+        assertFalse(firstPersonComparator.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPersonComparator.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPersonComparator.equals(secondPersonComparator));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class SortCommandTest {
+
+    @Test
+    public void equals() {
+        SortCommand firstSortCommand = new SortCommand(Arrays.asList(PREFIX_NAME,
+                PREFIX_STATUS), "asc");
+        SortCommand secondSortCommand = new SortCommand(Arrays.asList(PREFIX_NAME,
+                PREFIX_ADDRESS, PREFIX_EMAIL), "desc");
+
+        // same object -> returns true
+        assertTrue(firstSortCommand.equals(firstSortCommand));
+
+        // same values -> returns true
+        SortCommand firstSortCommandCopy = new SortCommand(Arrays.asList(PREFIX_NAME,
+                PREFIX_STATUS), "asc");
+        assertTrue(firstSortCommand.equals(firstSortCommandCopy));
+
+        // different types -> returns false
+        assertFalse(firstSortCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(firstSortCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstSortCommand.equals(secondSortCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_NO_PARAMETERS_SUPPLIED;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SortCommand;
+
+class SortCommandParserTest {
+    private SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsClearModulesCommand() {
+        List<Prefix> prefixes = new ArrayList<>();
+        prefixes.add(PREFIX_NAME);
+        prefixes.add(PREFIX_EMAIL);
+        prefixes.add(PREFIX_PHONE);
+        SortCommand correctCommand = new SortCommand(prefixes, "desc");
+        assertParseSuccess(parser, " n/ e/ p/ o/desc", correctCommand);
+    }
+
+    @Test
+    public void parse_noArgs_returnsClearModulesCommand() {
+        assertParseFailure(parser, "",
+                MESSAGE_NO_PARAMETERS_SUPPLIED);
+    }
+
+    @Test
+    public void parse_invalidArgs_returnsClearModulesCommand() {
+        assertParseFailure(parser, " 1 n/ o/desc",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, " n/ e/ p/ o/descending",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Add sort command to ModuleMateFinder. User guide excerpt for sorting below.

Most fields of Person now implement comparable interface. Add an ``o/`` tag for order. Sort command passes comparator to Addressbook model.

Barebones tests added, will add more tests later.


**UserGuide Excerpt**

Format: `sort [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STATUS] [t/TAG] [o/ORDER]​`

* Sorts list with specified field(s). For any two persons, latter fields will only be considered if preceding fields are equal.​ 
* Order of parameters is important except for that of `o/ORDER`.
* At least one of the optional fields must be provided (excluding order).
* Parameters are ignored except for order `o/asc`.
* Orders are optional and default order is "asc". Parameters of order must be either "asc" or "desc" and is case-insensitive. 

Examples:
* `sort n/ p/`  will sort the list by name first. If two persons have the same name, then sort by phone number.
* `sort n/ o/desc` will sort the list by name in descending order.
