### PR TITLE
Implement fix for Filter command not showing error message in UI

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsTagPredicate;
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsTagPredicate;
 
@@ -13,7 +14,8 @@ import seedu.address.model.person.NameContainsTagPredicate;
 public class FilterCommand extends Command {
 
     public static final String COMMAND_WORD = "filter";
-
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should have 2-3 letters prefix "
+            + "followed by 4 digits and an optional letter\n";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose tags contain any of "
             + "the specified keyword (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD \n"

--- a/src/main/java/seedu/address/logic/commands/StatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatusCommand.java
@@ -21,7 +21,6 @@ public class StatusCommand extends Command {
     public static final String COMMAND_WORD = "status";
 
     public static final String MESSAGE_ADD_STATUS_SUCCESS = "Added status to Person: %1$s";
-    public static final String MESSAGE_ADD_STATUS_FAILURE = "Tags should be either 'blacklist' or 'favourite'";
     public static final String MESSAGE_DELETE_STATUS_SUCCESS = "Removed status from Person: %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the status of the person identified "
             + "by the index number used in the last person listing. "

--- a/src/main/java/seedu/address/logic/commands/StatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatusCommand.java
@@ -22,6 +22,7 @@ public class StatusCommand extends Command {
 
     public static final String MESSAGE_ADD_STATUS_SUCCESS = "Added status to Person: %1$s";
     public static final String MESSAGE_DELETE_STATUS_SUCCESS = "Removed status from Person: %1$s";
+    public static final String MESSAGE_ADD_STATUS_FAILURE = "Tags should be either 'blacklist' or 'favourite'";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the status of the person identified "
             + "by the index number used in the last person listing. "
             + "Existing status will be overwritten by the input.\n"

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_MORE_TAGS_THAN_EXPECTE
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsTagPredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -30,6 +31,13 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             throw new ParseException(
                     String.format(MESSAGE_MORE_TAGS_THAN_EXPECTED, FilterCommand.MESSAGE_USAGE));
         }
+
+        if (!Tag.isValidTagName(tagKeywords[0])) {
+            throw new ParseException(
+                    String.format(FilterCommand.MESSAGE_CONSTRAINTS)
+            );
+        }
+
         // because we only allow ONE tag.
         String tagToFind = tagKeywords[0];
         return new FilterCommand(new NameContainsTagPredicate(tagToFind));

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -34,7 +34,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
 
         if (!Tag.isValidTagName(tagKeywords[0])) {
             throw new ParseException(
-                    String.format(FilterCommand.MESSAGE_CONSTRAINTS)
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_CONSTRAINTS)
             );
         }
 


### PR DESCRIPTION
Giving an invalid `tag` (renamed to module next time) will now show a proper error message in `ResultDisplay` panel.
![image](https://user-images.githubusercontent.com/70756909/157371549-0f60e4af-6f1e-4def-a129-8b90f66577a8.png)
