### PR TITLE
Sort clear test branch

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -237,17 +237,17 @@ Examples:
 
 Sort all people within address book.
 
-Format: `sort [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STATUS] [m/MODULE] [o/ORDER]​`
+Format: `sort [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STATUS] [m/MODULE]​`
 
 * Sorts list with specified field(s). For any two persons, latter fields will only be considered if preceding fields are equal.​
-* Order of parameters is important except for that of `o/ORDER`.
-* At least one of the optional fields must be provided (excluding order).
-* Parameters are ignored except for order `o/asc`.
-* Orders are optional and default order is "asc". Parameters of order must be either "asc" or "desc" and is case-insensitive. 
+* Order of fields is important and there must be at least one field.
+* Parameters determine whether field is sorted on ascending or descending order.
+* Parameters are optional must be either "asc", "desc" or an empty string "". Empty string "" is ascending by default.
+* Parameters are case-insensitive. 
 
 Examples:
-* `sort n/ p/`  will sort the list by name first. If two persons have the same name, then sort by phone number.
-* `sort n/ o/desc` will sort the list by name in descending order.
+* `sort n/asc p/desc`  will sort the list by name in ascending order first. If two persons have the same name, then sort by phone number in descending order.
+* `sort n/` will sort the list by name in descending order.
 
 ### Undo a command : `undo`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -247,7 +247,7 @@ Format: `sort [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STATUS] [m/MODULE]​`
 
 Examples:
 * `sort n/asc p/desc`  will sort the list by name in ascending order first. If two persons have the same name, then sort by phone number in descending order.
-* `sort n/` will sort the list by name in descending order.
+* `sort n/` will sort the list by name in ascending order.
 
 ### Undo a command : `undo`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -247,7 +247,7 @@ Format: `sort [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STATUS] [m/MODULE]​`
 
 Examples:
 * `sort n/asc p/desc`  will sort the list by name in ascending order first. If two persons have the same name, then sort by phone number in descending order.
-* `sort n/` will sort the list by name in ascending order.
+* `sort n/` will sort the list by name in ascending order by default.
 
 ### Undo a command : `undo`
 

--- a/docs/team/lawwm.md
+++ b/docs/team/lawwm.md
@@ -8,22 +8,24 @@ title: Wei Ming's Project Portfolio Page
 
 
 - **Administrative**:
-    - Fully set up team repo
-    - Set up User Guide for ease of update
 
 
 AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
 
 Given below are my contributions to the project.
 
-* **New Feature**: Added the ability to undo/redo previous commands.
-    * What it does: allows the user to undo all previous commands one at a time. Preceding undo commands can be reversed by using the redo command.
-    * Justification: This feature improves the product significantly because a user can make mistakes in commands and the app should provide a convenient way to rectify them.
-    * Highlights: This enhancement affects existing commands and commands to be added in future. It required an in-depth analysis of design alternatives. The implementation too was challenging as it required changes to existing commands.
-    * Credits: *{mention here if you reused any code/ideas from elsewhere or if a third-party library is heavily used in the feature so that a reader can make a more accurate judgement of how much effort went into the feature}*
+* **New Feature**: Added the ability to sort persons by specified fields.
+    * What it does: allows the user to sort all persons by specified fields.
+    * Justification: This feature improves the product significantly because a user can order persons based on what their needs. e.g. sort by status to track people by their status.
+    * Highlights: This enhancement affects existing attributes of persons to be added in future. It required an in-depth analysis of design alternatives.
 
-* **New Feature**: Added a history command that allows the user to navigate to previous commands using up/down keys.
+* **New Feature**: Added delete modules command that allows the user to navigate to previous commands using up/down keys.
+    * What it does: allows the user to delete modules by specifying the module name.
+    * Justification: This feature allows user to remove specified modules for a specific person.
 
+* **New Feature**: Added clear modules command that allows the user to easily clear all modules of a person.
+    * Justification: Clear all modules taken by a person so user does not have to delete each module individually. 
+    
 * **Code contributed**: [RepoSense link]()
 
 * **Project management**:
@@ -35,7 +37,7 @@ Given below are my contributions to the project.
 
 * **Documentation**:
     * User Guide:
-        * Added documentation for the features `delete` and `find` [\#72]()
+        * Added documentation for the features `deletemodule`, `clearmodules` and `sort` [\#72]()
         * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
     * Developer Guide:
         * Added implementation details of the `delete` feature.

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ORDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 
@@ -30,31 +29,29 @@ public class SortCommand extends Command {
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_STATUS + "STATUS] "
             + "[" + PREFIX_MODULE + "MODULE] "
-            + "[" + PREFIX_ORDER + "ORDER]\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_MODULE + " " + PREFIX_NAME
-            + " " + PREFIX_ORDER + "desc" + "\n";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_MODULE + "/asc " + PREFIX_NAME + "/desc " + "\n";
 
-    public static final String MESSAGE_SUCCESS = "Sorted successfully by %s order: %s";
+    public static final String MESSAGE_SUCCESS = "Sorted successfully: %s";
 
     private final PersonComparator personComparator;
     private final List<Prefix> fields;
-    private final String order;
+    private final List<String> orders;
     private final String successField;
     /**
      * @param fields modules to be deleted
      */
-    public SortCommand(List<Prefix> fields, String order, String successField) {
+    public SortCommand(List<Prefix> fields, List<String> orders, String successField) {
         this.successField = successField;
-        this.order = order;
+        this.orders = orders;
         this.fields = fields;
-        this.personComparator = new PersonComparator(fields, order);
+        this.personComparator = new PersonComparator(fields, orders);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.sortPerson(personComparator);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, order, successField));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, successField));
     }
 
     @Override
@@ -64,26 +61,30 @@ public class SortCommand extends Command {
                 && this.fields.equals(((SortCommand) other).fields)
                 && this.personComparator.equals(((SortCommand) other).personComparator)
                 && this.successField.equals(((SortCommand) other).successField)
-                && this.order.equals(((SortCommand) other).order); // instanceof handles null
+                && this.orders.equals(((SortCommand) other).orders); // instanceof handles null
     }
 
     public static class PersonComparator implements Comparator<Person> {
         private final List<Prefix> fields;
-        private final String order;
+        private final List<String> orders;
         /**
          * Create a comparator using the specified fields,
          * using the ordering implied by its iterator.
          * @param fields a list of field names
          */
-        public PersonComparator(List<Prefix> fields, String order) {
+        public PersonComparator(List<Prefix> fields, List<String> orders) {
+            assert fields.size() == orders.size();
             this.fields = fields;
-            this.order = order;
+            this.orders = orders;
         }
 
         @Override
         public int compare(Person o1, Person o2) {
-            for (Prefix field : fields) {
+            for (int i = 0; i < fields.size(); i++) {
                 int result = 0;
+                Prefix field = fields.get(i);
+                String order = orders.get(i);
+
                 if (PREFIX_NAME.equals(field)) {
                     result = o1.getName().compareTo(o2.getName());
 
@@ -101,7 +102,6 @@ public class SortCommand extends Command {
 
                 } else if (PREFIX_STATUS.equals(field)) {
                     result = o1.getStatus().compareTo(o2.getStatus());
-
                 }
 
                 if (order.equals("desc")) {
@@ -120,7 +120,7 @@ public class SortCommand extends Command {
             // short circuit if same object
             return (other instanceof PersonComparator)
                     && this.fields.equals(((PersonComparator) other).fields)
-                    && this.order.equals(((PersonComparator) other).order); // instanceof handles null
+                    && this.orders.equals(((PersonComparator) other).orders); // instanceof handles null
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -35,12 +35,34 @@ public class ArgumentTokenizer {
      * @param prefixes   Prefixes to find in the arguments string
      * @return List of prefix in the arguments string
      */
-    public static List<Prefix> sortPrefixOrder(String argsString, Prefix... prefixes) {
+    public static List<Prefix> getPrefixListInOrder(String argsString, Prefix... prefixes) {
         return findAllPrefixPositions(argsString, prefixes)
                 .stream()
                 .sorted((prefix1, prefix2) -> Integer.compare(prefix1.getStartPosition(), prefix2.getStartPosition()))
                 .map(PrefixPosition::getPrefix)
                 .collect(Collectors.toList());
+    }
+
+    public static List<String> getArgListInOrder(String argsString, Prefix... prefixes) {
+        List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
+        positions.sort((prefix1, prefix2) -> Integer.compare(prefix1.getStartPosition(), prefix2.getStartPosition()));
+
+        // Insert a PrefixPosition to represent the preamble
+        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), 0);
+        positions.add(0, preambleMarker);
+
+        // Add a dummy PrefixPosition to represent the end of the string
+        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix(""), argsString.length());
+        positions.add(endPositionMarker);
+
+        List<String> orderList = new ArrayList<>();
+        for (int i = 1; i < positions.size() - 1; i++) {
+            // Extract and store arguments
+            String argValue = extractArgumentValue(argsString, positions.get(i), positions.get(i + 1));
+            orderList.add(argValue);
+        }
+
+        return orderList;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,6 +12,4 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_MODULE = new Prefix("m/");
     public static final Prefix PREFIX_STATUS = new Prefix("s/");
-    public static final Prefix PREFIX_ORDER = new Prefix("o/");
-
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteModuleCommandParser.java
@@ -15,11 +15,6 @@ import seedu.address.logic.commands.DeleteModuleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Module;
 
-
-
-
-
-
 /**
  * Parses input arguments and creates a new DeleteCommand object
  */

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ORDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 
@@ -31,9 +30,12 @@ public class SortCommandParser implements Parser<SortCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
-                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_STATUS, PREFIX_MODULE, PREFIX_ORDER);
+                        PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_STATUS, PREFIX_MODULE);
 
-        List<Prefix> prefixes = ArgumentTokenizer.sortPrefixOrder(args, PREFIX_NAME, PREFIX_PHONE,
+        List<Prefix> prefixes = ArgumentTokenizer.getPrefixListInOrder(args, PREFIX_NAME, PREFIX_PHONE,
+                PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_STATUS, PREFIX_MODULE);
+
+        List<String> orders = ArgumentTokenizer.getArgListInOrder(args, PREFIX_NAME, PREFIX_PHONE,
                 PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_STATUS, PREFIX_MODULE);
 
         if (prefixes.size() == 0) {
@@ -44,18 +46,15 @@ public class SortCommandParser implements Parser<SortCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
 
-        String successField = formatFields(prefixes);
-
-        if (argMultimap.getValue(PREFIX_ORDER).isPresent()) {
-            String order = argMultimap.getValue(PREFIX_ORDER).get().toLowerCase();
-            if (!order.equals("asc") && !order.equals("desc")) {
+        for (String order : orders) {
+            String uppercaseOrder = order.toUpperCase();
+            if (!uppercaseOrder.equals("ASC") && !uppercaseOrder.equals("DESC") && !uppercaseOrder.equals("")) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
             }
-            String formattedOrder = order.equals("asc") ? "ascending" : "descending";
-            return new SortCommand(prefixes, formattedOrder, successField);
         }
 
-        return new SortCommand(prefixes, "ascending", successField);
+        String successField = formatFields(prefixes, orders);
+        return new SortCommand(prefixes, orders, successField);
     }
 
     /**
@@ -63,10 +62,13 @@ public class SortCommandParser implements Parser<SortCommand> {
      * @param fields the list of prefixes to be displayed
      * @return the formatted success message
      */
-    public static String formatFields(List<Prefix> fields) throws ParseException {
-        List<String> formattedFields = new ArrayList<>();
-        for (Prefix field : fields) {
-            formattedFields.add(formatPrefix(field));
+    public static String formatFields(List<Prefix> fields, List<String> orders) throws ParseException {
+        List<List<String>> formattedFields = new ArrayList<>();
+        for (int i = 0; i < fields.size(); i++) {
+            List<String> formattedField = new ArrayList<>();
+            formattedField.add(formatPrefix(fields.get(i)));
+            formattedField.add(orders.get(i).toUpperCase());
+            formattedFields.add(formattedField);
         }
         return formattedFields.toString();
     }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -21,6 +21,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class SortCommandParser implements Parser<SortCommand> {
 
+    private static final String defaultOrder = "ASC";
+
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an SortCommand object for execution.
@@ -67,7 +69,11 @@ public class SortCommandParser implements Parser<SortCommand> {
         for (int i = 0; i < fields.size(); i++) {
             List<String> formattedField = new ArrayList<>();
             formattedField.add(formatPrefix(fields.get(i)));
-            formattedField.add(orders.get(i).toUpperCase());
+            if (orders.get(i).equals("")) {
+                formattedField.add(defaultOrder);
+            } else {
+                formattedField.add(orders.get(i).toUpperCase());
+            }
             formattedFields.add(formattedField);
         }
         return formattedFields.toString();

--- a/src/test/java/seedu/address/logic/commands/DeleteModuleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteModuleCommandTest.java
@@ -3,16 +3,20 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -26,8 +30,7 @@ class DeleteModuleCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        List<Module> modules = personToDelete.getModules().stream()
-                .collect(Collectors.toList());
+        List<Module> modules = new ArrayList<>(personToDelete.getModules());
         DeleteModuleCommand deleteCommand = new DeleteModuleCommand(INDEX_FIRST_PERSON, modules);
 
         String expectedMessage = String.format(DeleteModuleCommand.MESSAGE_SUCCESS,
@@ -38,6 +41,40 @@ class DeleteModuleCommandTest {
         expectedModel.setPerson(personToDelete, editedPerson);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_failure() {
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        List<Module> modules = new ArrayList<>(personToDelete.getModules());
+        DeleteModuleCommand deleteCommand = new DeleteModuleCommand(Index.fromOneBased(1000), modules);
+
+        String expectedMessage = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+
+        assertCommandFailure(deleteCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_modulesToDeleteDoesNotExistListUnfilteredList_failure() {
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        List<Module> modules = new ArrayList<>(personToDelete.getModules());
+        List<Module> modulesPersonDoesNotHave = new ArrayList<>();
+
+        // Change first letter of modules, e.g. "CS2106" to "DS2106"
+        for (Module module : modules) {
+            String moduleString = module.toString();
+            String moduleName = moduleString.substring(1, moduleString.length() - 1);
+            String changedFirstLetterModuleName = String.valueOf((char) (moduleName.charAt(0) + 1));
+            String alteredModuleName = changedFirstLetterModuleName + moduleName.substring(1);
+            System.out.println(alteredModuleName);
+            modulesPersonDoesNotHave.add(new Module(alteredModuleName));
+        }
+
+        DeleteModuleCommand deleteCommand = new DeleteModuleCommand(INDEX_FIRST_PERSON, modulesPersonDoesNotHave);
+
+        String expectedMessage = String.format(DeleteModuleCommand.MESSAGE_FAILURE, modulesPersonDoesNotHave);
+
+        assertCommandFailure(deleteCommand, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/PersonComparatorTest.java
+++ b/src/test/java/seedu/address/logic/commands/PersonComparatorTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.SortCommand.PersonComparator;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.Arrays;
@@ -13,7 +15,31 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Person;
+import seedu.address.testutil.TypicalPersons;
+
 class PersonComparatorTest {
+    @Test
+    public void compare_valid_person() {
+        Person alice = TypicalPersons.ALICE;
+        Person bob = TypicalPersons.BOB;
+
+        PersonComparator nameComparator = new PersonComparator(Arrays.asList(PREFIX_NAME), Arrays.asList("desc"));
+        PersonComparator emailComparator = new PersonComparator(Arrays.asList(PREFIX_EMAIL), Arrays.asList("asc"));
+        PersonComparator addressComparator = new PersonComparator(Arrays.asList(PREFIX_ADDRESS), Arrays.asList("asc"));
+        PersonComparator statusComparator = new PersonComparator(Arrays.asList(PREFIX_STATUS), Arrays.asList("asc"));
+        PersonComparator phoneComparator = new PersonComparator(Arrays.asList(PREFIX_PHONE), Arrays.asList("asc"));
+        PersonComparator moduleComparator = new PersonComparator(Arrays.asList(PREFIX_MODULE), Arrays.asList("asc"));
+
+        assertTrue(nameComparator.compare(alice, bob) == -1 * alice.getName().compareTo(bob.getName()));
+        assertTrue(emailComparator.compare(alice, bob) == alice.getEmail().compareTo(bob.getEmail()));
+        assertTrue(addressComparator.compare(alice, bob) == alice.getAddress().compareTo(bob.getAddress()));
+        assertTrue(statusComparator.compare(alice, bob) == alice.getStatus().compareTo(bob.getStatus()));
+        assertTrue(phoneComparator.compare(alice, bob) == alice.getPhone().compareTo(bob.getPhone()));
+        assertTrue(moduleComparator.compare(alice, bob)
+                == Integer.compare(alice.getModules().size(), bob.getModules().size()));
+    }
+
     @Test
     public void equals() {
         List<String> firstOrder = Arrays.asList("asc", "asc", "desc", "desc");

--- a/src/test/java/seedu/address/logic/commands/PersonComparatorTest.java
+++ b/src/test/java/seedu/address/logic/commands/PersonComparatorTest.java
@@ -9,23 +9,27 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 class PersonComparatorTest {
     @Test
     public void equals() {
+        List<String> firstOrder = Arrays.asList("asc", "asc", "desc", "desc");
+        List<String> secondOrder = Arrays.asList("asc", "asc");
+
         PersonComparator firstPersonComparator = new PersonComparator(Arrays.asList(PREFIX_NAME, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_STATUS), "asc");
+                PREFIX_ADDRESS, PREFIX_STATUS), firstOrder);
         PersonComparator secondPersonComparator = new PersonComparator(Arrays.asList(PREFIX_NAME,
-                PREFIX_STATUS), "desc");
+                PREFIX_STATUS), secondOrder);
 
         // same object -> returns true
         assertTrue(firstPersonComparator.equals(firstPersonComparator));
 
         // same values -> returns true
         PersonComparator firstPersonComparatorCopy = new PersonComparator(Arrays.asList(PREFIX_NAME, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_STATUS), "asc");
+                PREFIX_ADDRESS, PREFIX_STATUS), firstOrder);
         assertTrue(firstPersonComparator.equals(firstPersonComparatorCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -2,9 +2,14 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,8 +19,32 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.SortCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 class SortCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validSortCommand_sortsList() {
+        try {
+            List<Prefix> prefixes = Arrays.asList(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                    PREFIX_ADDRESS, PREFIX_STATUS, PREFIX_MODULE);
+            List<String> orders = Arrays.asList("asc", "asc", "desc", "asc", "asc", "desc");
+            String successMessage = SortCommandParser.formatFields(prefixes, orders);
+            SortCommand sortCommand = new SortCommand(prefixes, orders, successMessage);
+
+            String expectedMessage = String.format(SortCommand.MESSAGE_SUCCESS, successMessage);
+
+            ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+            expectedModel.sortPerson(new SortCommand.PersonComparator(prefixes, orders));
+            assertCommandSuccess(sortCommand, model, expectedMessage, expectedModel);
+
+        } catch (ParseException pe) {
+            assert false;
+        }
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -21,18 +21,20 @@ class SortCommandTest {
     public void equals() {
         List<Prefix> firstPrefixList = Arrays.asList(PREFIX_NAME, PREFIX_STATUS);
         List<Prefix> secondPrefixList = Arrays.asList(PREFIX_NAME, PREFIX_STATUS, PREFIX_EMAIL);
+        List<String> firstOrder = Arrays.asList("asc", "asc");
+        List<String> secondOrder = Arrays.asList("asc", "asc", "desc");
         try {
             SortCommand firstSortCommand = new SortCommand(firstPrefixList,
-                    "asc", SortCommandParser.formatFields(firstPrefixList));
+                    firstOrder, SortCommandParser.formatFields(firstPrefixList, firstOrder));
             SortCommand secondSortCommand = new SortCommand(secondPrefixList,
-                    "desc", SortCommandParser.formatFields(secondPrefixList));
+                    secondOrder, SortCommandParser.formatFields(secondPrefixList, secondOrder));
 
             // same object -> returns true
             assertTrue(firstSortCommand.equals(firstSortCommand));
 
             // same values -> returns true
             SortCommand firstSortCommandCopy = new SortCommand(firstPrefixList,
-                    "asc", SortCommandParser.formatFields(firstPrefixList));
+                    firstOrder, SortCommandParser.formatFields(firstPrefixList, firstOrder));
             assertTrue(firstSortCommand.equals(firstSortCommandCopy));
 
             // different types -> returns false

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -2,14 +2,15 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_NO_PARAMETERS_SUPPLIED;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,12 +25,13 @@ class SortCommandParserTest {
     @Test
     public void parse_validArgs_returnsSortModulesCommand() {
         try {
-            List<Prefix> prefixes = Arrays.asList(PREFIX_NAME, PREFIX_STATUS, PREFIX_EMAIL);
-            List<String> firstOrder = Arrays.asList("asc", "asc", "desc");
+            List<Prefix> prefixes = Arrays.asList(PREFIX_NAME, PREFIX_PHONE,
+                    PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_STATUS, PREFIX_MODULE);
+            List<String> firstOrder = Arrays.asList("asc", "asc", "desc", "asc", "asc", "desc");
 
             SortCommand correctCommand = new SortCommand(prefixes,
                     firstOrder, SortCommandParser.formatFields(prefixes, firstOrder));
-            assertParseSuccess(parser, " n/asc s/asc e/desc", correctCommand);
+            assertParseSuccess(parser, " n/asc p/asc e/desc a/asc s/asc m/desc", correctCommand);
         } catch (ParseException e) {
             assert false;
         }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -5,10 +5,12 @@ import static seedu.address.commons.core.Messages.MESSAGE_NO_PARAMETERS_SUPPLIED
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -20,32 +22,31 @@ class SortCommandParserTest {
     private SortCommandParser parser = new SortCommandParser();
 
     @Test
-    public void parse_validArgs_returnsClearModulesCommand() {
+    public void parse_validArgs_returnsSortModulesCommand() {
         try {
-            List<Prefix> prefixes = new ArrayList<>();
-            prefixes.add(PREFIX_NAME);
-            prefixes.add(PREFIX_EMAIL);
-            prefixes.add(PREFIX_PHONE);
+            List<Prefix> prefixes = Arrays.asList(PREFIX_NAME, PREFIX_STATUS, PREFIX_EMAIL);
+            List<String> firstOrder = Arrays.asList("asc", "asc", "desc");
+
             SortCommand correctCommand = new SortCommand(prefixes,
-                    "descending", SortCommandParser.formatFields(prefixes));
-            assertParseSuccess(parser, " n/ e/ p/ o/desc", correctCommand);
+                    firstOrder, SortCommandParser.formatFields(prefixes, firstOrder));
+            assertParseSuccess(parser, " n/asc s/asc e/desc", correctCommand);
         } catch (ParseException e) {
             assert false;
         }
     }
 
     @Test
-    public void parse_noArgs_returnsClearModulesCommand() {
+    public void parse_noArgs_returnsSortModulesCommand() {
         assertParseFailure(parser, "",
                 String.format(MESSAGE_NO_PARAMETERS_SUPPLIED, SortCommand.MESSAGE_USAGE));
     }
 
     @Test
-    public void parse_invalidArgs_returnsClearModulesCommand() {
-        assertParseFailure(parser, " 1 n/ o/desc",
+    public void parse_invalidArgs_returnsSortModulesCommand() {
+        assertParseFailure(parser, " 1 n/asc m/desc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
 
-        assertParseFailure(parser, " n/ e/ p/ o/descending",
+        assertParseFailure(parser, " n/asc e/desc p/asccc",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Changed syntax for sorting to be more similar to SQL `order by`.

**Previous:**
`sort a/ p/ m/ o/asc`
- unable to choose order for each specific field. 
- cosmetically awkward to have no parameter for each field
- requires additional order prefix

**Updated:**
`sort a/ p/desc m/asc`
- Removed order prefix
- Can choose order ("ascending" or "descending") for each field

**Miscellaneous:**
Added additional tests to sort and delete module features.
