### PR TITLE
Update add modules to reflect duplicate modules

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -38,6 +39,8 @@ public class AddModuleCommand extends Command {
      * Arg2 is List of Modules added
      */
     public static final String MESSAGE_SUCCESS = "Added Modules for %s: %s";
+    public static final String MESSAGE_DUPLICATE_MODULES_EXIST = "Some Module(s) already exists, ";
+    public static final String MESSAGE_NO_NEW_MODULES_ADDED = "no new Modules added, current Modules that %s has: %s";
 
     private final Index targetIndex;
     private final List<Module> modulesToAdd;
@@ -79,7 +82,7 @@ public class AddModuleCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.getName(), modulesToAddActual));
+        return getCommandResult(personToEdit, editedPerson, modulesToAddActual);
     }
 
     /**
@@ -108,5 +111,43 @@ public class AddModuleCommand extends Command {
                 || (other instanceof AddModuleCommand // instanceof handles nulls
                 && targetIndex.equals(((AddModuleCommand) other).targetIndex)) // state check
                 && modulesToAdd.equals(((AddModuleCommand) other).modulesToAdd);
+    }
+
+    /**
+     * @return true if personToEdit contains any modules in proposedModules
+     */
+    private boolean hasModulesInCommon(Person personToEdit, List<Module> proposedModules) {
+        Set<Module> existingModules = personToEdit.getModules();
+        return !Collections.disjoint(existingModules, proposedModules);
+    }
+
+    /**
+     * Function to get a List of non-duplicated modules added to the Person
+     * @return List of non-duplicated modules, which may be empty if no unique modules exist
+     */
+    private List<Module> getNewModules(Person personToEdit, List<Module> proposedModules) {
+        Set<Module> existingModules = personToEdit.getModules();
+        proposedModules.removeAll(existingModules);
+
+        return proposedModules;
+    }
+
+    private CommandResult getCommandResult(Person personToEdit, Person editedPerson, List<Module> modulesToAddActual) {
+        if (hasModulesInCommon(personToEdit, modulesToAddActual)) {
+            List<Module> newModules = getNewModules(personToEdit, modulesToAddActual);
+
+            String feedback;
+            if (newModules.isEmpty()) {
+                return new CommandResult(String.format(MESSAGE_DUPLICATE_MODULES_EXIST + MESSAGE_NO_NEW_MODULES_ADDED,
+                        editedPerson.getName(),
+                        editedPerson.getModules()));
+            } else {
+                return new CommandResult(String.format(MESSAGE_DUPLICATE_MODULES_EXIST + MESSAGE_SUCCESS,
+                        editedPerson.getName(),
+                        newModules));
+            }
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, editedPerson.getName(), modulesToAddActual));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddModuleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddModuleCommandTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_PM1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_SWE;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -28,11 +28,10 @@ class AddModuleCommandTest {
     @Test
     void execute_addModuleUnfilteredList_success() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(firstPerson).withModules(VALID_MODULE_SWE, VALID_MODULE).build();
+        Person editedPerson = new PersonBuilder(firstPerson).withModules(VALID_MODULE_SWE, VALID_MODULE_PM1).build();
 
         List<Module> modules = new ArrayList<>();
-        modules.add(new Module(VALID_MODULE_SWE));
-        modules.add(new Module(VALID_MODULE));
+        modules.add(new Module(VALID_MODULE_PM1));
         AddModuleCommand addModuleCommand = new AddModuleCommand(INDEX_FIRST_PERSON, modules);
 
         String expectedMessage = String.format(AddModuleCommand.MESSAGE_SUCCESS, firstPerson.getName(), modules);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -38,6 +38,7 @@ public class CommandTestUtil {
     public static final String VALID_STATUS_BOB = Person.BLACKLIST;
     public static final String VALID_MODULE = "CS2101";
     public static final String VALID_MODULE_SWE = "CS2103T";
+    public static final String VALID_MODULE_PM1 = "CS1101S";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;


### PR DESCRIPTION
Add Modules Command now shows the User more relevant success messages depending on the following cases:
1. Modules from user input contain only new modules
2. Modules from user input contain some new modules
3. Modules from user input contain no new modules

Case 1:
* Shows new modules added
Case 2:
* Shows new modules added, with warning that some modules already exist
Case 3:
* Shows warning that modules already exist, no new modules added, along with list of existing modules (to show User that despite the "error", no further actions associated with typical failed commands need to be taken)

Fixes #71 