### PR TITLE
Fix empty table background colour

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -89,6 +89,7 @@
 
 .list-view {
     -fx-background-insets: 0;
+    -fx-background-color: derive(#5B84B1FF, 20%);
     -fx-padding: 0;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70756909/160748144-e0021894-8635-41a7-9242-6d86571b65b1.png)
Fixed as shown.

Closes #114 